### PR TITLE
Adding default behavior to HandlerWriteProperties: either tableName o…

### DIFF
--- a/task-processor-common/src/main/java/com/pcistudio/task/procesor/HandlerProperties.java
+++ b/task-processor-common/src/main/java/com/pcistudio/task/procesor/HandlerProperties.java
@@ -182,6 +182,7 @@ public final class HandlerProperties extends HandlerWriteProperties {
         public HandlerProperties build() {
             Assert.notNull(taskHandler, "TaskHandler cannot be null");
             taskHandlerType = discoverTaskHandlerType(taskHandler);
+            checkRequiredFields();
             return new HandlerProperties(this);
         }
 

--- a/task-processor-common/src/main/java/com/pcistudio/task/procesor/HandlerWriteProperties.java
+++ b/task-processor-common/src/main/java/com/pcistudio/task/procesor/HandlerWriteProperties.java
@@ -16,6 +16,7 @@ public class HandlerWriteProperties {
     private final boolean encrypt;
 
     protected HandlerWriteProperties(HandlerWritePropertiesBuilder<?> builder) {
+
         this.handlerName = Objects.requireNonNullElse(builder.handlerName, builder.tableName);
         this.tableName = Objects.requireNonNullElse(builder.tableName, builder.handlerName);
         this.encrypt = builder.encrypt;
@@ -52,10 +53,14 @@ public class HandlerWriteProperties {
         }
 
         public HandlerWriteProperties build() {
+            checkRequiredFields();
+            return new HandlerWriteProperties(this);
+        }
+
+        protected void checkRequiredFields() {
             if (tableName == null && handlerName == null) {
                 throw new IllegalArgumentException("tableName or handlerName must be set");
             }
-            return new HandlerWriteProperties(this);
         }
     }
 

--- a/task-processor-common/src/main/java/com/pcistudio/task/procesor/HandlerWriteProperties.java
+++ b/task-processor-common/src/main/java/com/pcistudio/task/procesor/HandlerWriteProperties.java
@@ -1,6 +1,10 @@
 package com.pcistudio.task.procesor;
 
+import com.pcistudio.task.procesor.util.Assert;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.Getter;
+
+import java.util.Objects;
 
 @Getter
 public class HandlerWriteProperties {
@@ -12,8 +16,8 @@ public class HandlerWriteProperties {
     private final boolean encrypt;
 
     protected HandlerWriteProperties(HandlerWritePropertiesBuilder<?> builder) {
-        this.handlerName = builder.handlerName;
-        this.tableName = builder.tableName;
+        this.handlerName = Objects.requireNonNullElse(builder.handlerName, builder.tableName);
+        this.tableName = Objects.requireNonNullElse(builder.tableName, builder.handlerName);
         this.encrypt = builder.encrypt;
     }
 
@@ -22,16 +26,22 @@ public class HandlerWriteProperties {
     }
 
     public static class HandlerWritePropertiesBuilder<T extends HandlerWritePropertiesBuilder<T>> {
-        private String tableName = "default";
-        private String handlerName = "default";
+        @Nullable
+        private String tableName;
+        @Nullable
+        private String handlerName;
         private boolean encrypt = false;
 
         public T tableName(String tableName) {
+            Assert.notNull(tableName, "tableName cannot be null");
+            Assert.isFalse(tableName.isBlank(), "tableName cannot be empty");
             this.tableName = tableName;
             return (T) this;
         }
 
         public T handlerName(String handlerName) {
+            Assert.notNull(handlerName, "handlerName cannot be null");
+            Assert.isFalse(handlerName.isBlank(), "handlerName cannot be empty");
             this.handlerName = handlerName;
             return (T) this;
         }
@@ -42,6 +52,9 @@ public class HandlerWriteProperties {
         }
 
         public HandlerWriteProperties build() {
+            if (tableName == null && handlerName == null) {
+                throw new IllegalArgumentException("tableName or handlerName must be set");
+            }
             return new HandlerWriteProperties(this);
         }
     }

--- a/task-processor-common/src/test/java/com/pcistudio/task/procesor/HandlerWritePropertiesTest.java
+++ b/task-processor-common/src/test/java/com/pcistudio/task/procesor/HandlerWritePropertiesTest.java
@@ -1,0 +1,51 @@
+package com.pcistudio.task.procesor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HandlerWritePropertiesTest {
+
+    @org.junit.jupiter.api.Test
+    void builder() {
+        HandlerWriteProperties handlerWriteProperties = HandlerWriteProperties.builder()
+                .tableName("test_table")
+                .handlerName("test_handler")
+                .encrypt(true)
+                .build();
+        assertEquals("test_table", handlerWriteProperties.getTableName());
+        assertEquals("test_handler", handlerWriteProperties.getHandlerName());
+        assertTrue(handlerWriteProperties.isEncrypt());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testHandlerNotSetUseTableName() {
+        HandlerWriteProperties handlerWriteProperties = HandlerWriteProperties.builder()
+                .tableName("test_table")
+                .encrypt(true)
+                .build();
+        assertEquals("test_table", handlerWriteProperties.getTableName());
+        assertEquals("test_table", handlerWriteProperties.getHandlerName());
+        assertTrue(handlerWriteProperties.isEncrypt());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testTableNameNotSetUseHandlerName() {
+        HandlerWriteProperties handlerWriteProperties = HandlerWriteProperties.builder()
+                .handlerName("test_handler")
+                .encrypt(true)
+                .build();
+        assertEquals("test_handler", handlerWriteProperties.getTableName());
+        assertEquals("test_handler", handlerWriteProperties.getHandlerName());
+        assertTrue(handlerWriteProperties.isEncrypt());
+    }
+
+    @org.junit.jupiter.api.Test
+    void testNonTableNameOrUseHandlerNameSet() {
+        HandlerWriteProperties.HandlerWritePropertiesBuilder<?> builder = HandlerWriteProperties.builder()
+                .encrypt(true);
+
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, builder::build);
+
+        assertEquals("tableName or handlerName must be set", illegalArgumentException.getMessage());
+    }
+
+}


### PR DESCRIPTION
Adding default behavior to HandlerWriteProperties: either tableName or handlerName must be set, and if one is not present, takes the others value .